### PR TITLE
data-cursor-stick centered in wide elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -378,7 +378,7 @@ export default class MouseFollower {
         const rect = el.getBoundingClientRect();
         this.stick = {
             y: rect.top + (rect.height / 2),
-            x: rect.left + (rect.height / 2),
+            x: rect.left + (rect.width / 2),
         };
     }
 


### PR DESCRIPTION
Sticky mode failed to center properly with an item aspect ratio greater than 1/1

https://user-images.githubusercontent.com/48869708/172047314-c41e3705-2d2a-410c-8dd0-bf556dfc6487.mp4