### PR TITLE
Change 'mousemove' to 'pointermove'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -241,9 +241,9 @@ export default class MouseFollower {
             this.container.addEventListener('mousedown', this.event.mousedown, {passive: true});
             this.container.addEventListener('mouseup', this.event.mouseup, {passive: true});
         }
-        this.container.addEventListener('mousemove', this.event.mousemove, {passive: true});
+        this.container.addEventListener('pointermove', this.event.mousemove, {passive: true});
         if (this.options.visible) {
-            this.container.addEventListener('mousemove', this.event.mousemoveOnce, {
+            this.container.addEventListener('pointermove', this.event.mousemoveOnce, {
                 passive: true,
                 once: true,
             });
@@ -570,8 +570,8 @@ export default class MouseFollower {
         this.container.removeEventListener('mouseenter', this.event.mouseenter);
         this.container.removeEventListener('mousedown', this.event.mousedown);
         this.container.removeEventListener('mouseup', this.event.mouseup);
-        this.container.removeEventListener('mousemove', this.event.mousemove);
-        this.container.removeEventListener('mousemove', this.event.mousemoveOnce);
+        this.container.removeEventListener('pointermove', this.event.mousemove);
+        this.container.removeEventListener('pointermove', this.event.mousemoveOnce);
         this.container.removeEventListener('mouseover', this.event.mouseover);
         this.container.removeEventListener('mouseout', this.event.mouseout);
         if (this.el) {


### PR DESCRIPTION
I've had some lags when working with sliders, especially when I'm dragging a slider. The lags disappeared when I changed 'mousemove' to 'pointermove'.

There were lags when working with [swiper](https://swiperjs.com/) and [flickity](https://flickity.metafizzy.co/) sliders. I haven't tested it on the other sliders.




https://user-images.githubusercontent.com/25268319/188215522-1e6f42ae-f1d8-4bd5-a619-db67f14bc6d8.mov


https://user-images.githubusercontent.com/25268319/188215531-5e75defd-a239-4926-9300-e0eb1913d863.mov


